### PR TITLE
version 0.0.9, reverting back to using vdc-download

### DIFF
--- a/app/scripts/services/api-explorer.js
+++ b/app/scripts/services/api-explorer.js
@@ -44,13 +44,17 @@
                 });
                 return productListNoVersions;
             },
-            // this utility function is to work around an issue with insecure certificates on vdc-download.vmware.com
+            // this utility function is to work around an issue with insecure certificates on vdc-download.vmware.com.
+            // As it turns on we figured out that in fact the certificate is OK, but this is a bug in many webkit browsers
+            // including Chrome.  For Chrome browsers version 57 or later is needed (63 has the issue).  It seems that it
+            // is also an issue for Safari.
             fixVMwareDownloadUrl : function(url) {
-                if (url) {
-                    return url.replace("vdc-download", "vdc-repo");
-                } else {
-                    return url;
-                }
+               return url;
+               // if (url) {
+               //     return url.replace("vdc-download", "vdc-repo");
+               // } else {
+               //     return url;
+               // }
             }
         };
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
It turns out the issue is really that the certificate on vdc-download suffers from a bug
in Chrome and other browsers.  Updating to Chrome 57 and clearly the cache will remove the issue.
Reverting back to vdc-download for URLs so that performance is better

Signed-off-by: Aaron Spear <aspear@vmware.com>