### PR TITLE
Added additional variables to control display of the filter pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 This project is a lightweight HTML5/AngularJS 1.x component that implements an API Explorer for VMware APIs.  This
 component has minimal dependencies and can be embedded in any product that has an embedded web server.
 
+If you wish to see an instance of this project in action, check out the [VMware Platypus Project](http://github.com/vmware/platypus/), 
+which is a package of this API Explorer in a convenient Docker container.
+
 ###Features
 * Support for Swagger, RAML, or generic HTML API documentation
 * Swagger and RAML components can make API calls using the client browsers network connectivity.
@@ -29,22 +32,55 @@ configure the component. For now you will have to do a build (grunt build) and c
 the contents of the dist folder into your tree.
 
 ### Component configuration
-You can config the api-explorer by setting environment variables in config.js file (shown below).  By default, both the local APIs and remote APIs are enabled.  To disable the remote APIs, set the "window.config.enableRemote=false". For local APIs, you need to set the "local.json" file path in the "window.config.localApiEndPoint" variable. You can also specify the product name in "window.config.productCatalog" variable to only get the remote APIs for the specified product.  By default, the "window.config.productCatalog" is not set and all remote APIs are shown.
+You can config the api-explorer by setting environment variables in config.js file (shown below).  By default, both the local APIs and remote APIs are enabled.  To disable the remote APIs, set the "window.config.enableRemote=false". For local APIs, you need to set the "local.json" file path in the "window.config.localApiEndPoint" variable. 
+
+It is possible to specify default settings for filter values in the defaultFilters variable.
+This can be used to only display APIs for a particular product for example.
+
+Additionally if you wish to prevent the user from being able to change a particular filter 
+selection, you can specify a "true" value for one of the  window.config.hide* variables. These
+values cause either all of the filters (in the case of "hideFilters"), or a particular filter
+pane to be hidden by default.
+
+In the example below, we create an API explorer that only displays local vSphere APIs by
+setting defaultFilters values as well as hideFilters = true.
 
 ```javascript
 
-  ## Enable local APIs
+  // Whether or not to enable debug mode
+  // Setting this to false will disable console output
+  window.config.enableDebug = false;
+  
+  // Whether or not to enable local APIs
   window.config.enableLocal = true;
-
-  ## local APIs endpoint
+    
+  // local APIs endpoint
   window.config.localApiEndPoint = "local.json";
-
-  ## Enable remote APIs
+  
+  // Whether or not to enable remote APIs and resources
   window.config.enableRemote = true;
 
-  ## Product catalog
-  ## Available values are: vSphere, NSX, vCenter Server, vCloud Air, vCloud Suite, Virtual SAN, vRealize Suite
-  window.config.productCatalog = "vSphere";
+  // you can customize the text that is displayed above the APIs, to scope
+  // to a particular product for example.
+  window.config.apiListHeaderText = "vSphere APIs";
+
+  // default filtering to apply to the window after the initial load is done.
+  window.config.defaultFilters = {
+      keywords : "",
+      products : ["vSphere"],
+      languages: [],
+      types: [],
+      sources: ["local"]
+  };
+
+  // Default control over display of filters.  This has nothing to do do with the actual values of the filters,
+  // only over the display of them.  If all filters or a particular filter pane are not displayed and yet there is
+  // a defaultFilters value for it, the user will not be able to change the value. This can be used to scope to a
+  // particular product for example.
+  window.config.hideFilters = true;             // if true, the filter pane is not displayed at all
+  window.config.hideProductFilter = false;       // if true, the products filter is hidden
+  window.config.hideLanguageFilter = false;      // if true, the language filter is hidden
+  window.config.hideSourcesFilter = false;       // if true, the sources filter is hidden
 ```
 
 ## Contributing

--- a/app/config.js
+++ b/app/config.js
@@ -26,10 +26,10 @@
   // default filtering to apply to the window after the initial load is done.
   window.config.defaultFilters = {
       keywords : "",
-      products : ["vSphere"],
+      products : [],
       languages: [],
       types: [],
-      sources: ["local","remote"]
+      sources: []
   };
 
   // Default control over display of filters.  This has nothing to do do with the actual values of the filters,

--- a/app/config.js
+++ b/app/config.js
@@ -19,24 +19,28 @@
   // Whether or not to enable remote APIs and resources
   window.config.enableRemote = true;
 
-  // default filtering to apply to the window after the initial load is done.  This is different
-  // from enablinh remote or local as well a productCatalog because it is possible for the user to
-  //change the selection after page load
+  // you can customize the text that is displayed above the APIs, to scope
+  // to a particular product for example.
+  window.config.apiListHeaderText = "Available APIs";
+
+  // default filtering to apply to the window after the initial load is done.
   window.config.defaultFilters = {
       keywords : "",
-      products : [],
+      products : ["vSphere"],
       languages: [],
       types: [],
-      sources: []
+      sources: ["local","remote"]
   };
-  
-  // Product catalog: if specified, only the products in the list are added to the GUI irrespective of
-  // any selection that the user makes.  If you only ever want a subset of products available this is the
-  // option to use.  If however you want to have DEFAULT selections and be able to change them, you should
-  // instead use the defaultFilters.
-  // Available values are: vSphere, NSX, vCenter Server, vCloud Air, vCloud Suite, Virtual SAN, vRealize Suite
-  //window.config.productCatalog = "vRealize Automation";
-  
+
+  // Default control over display of filters.  This has nothing to do do with the actual values of the filters,
+  // only over the display of them.  If all filters or a particular filter pane are not displayed and yet there is
+  // a defaultFilters value for it, the user will not be able to change the value. This can be used to scope to a
+  // particular product for example.
+  window.config.hideFilters = false;             // if true, the filter pane is not displayed at all
+  window.config.hideProductFilter = false;       // if true, the products filter is hidden
+  window.config.hideLanguageFilter = false;      // if true, the language filter is hidden
+  window.config.hideSourcesFilter = false;       // if true, the sources filter is hidden
+
   // Remote APIs endpoint.  
   window.config.remoteSampleExchangeApiEndPoint = "https://apigw.vmware.com/sampleExchange/v1";
   window.config.remoteApiEndPoint = "https://vdc-repo.vmware.com/apix";

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -71,6 +71,15 @@ app.run(function($rootScope, $window) {
       // set any default filter selections
       $rootScope.settings.defaultFilters = env.defaultFilters;
 
+      // defaults for control over the filter pane
+      $rootScope.settings.hideFilters = env.hideFilters;
+      $rootScope.settings.hideProductFilter = env.hideProductFilter;
+      $rootScope.settings.hideLanguageFilter = env.hideLanguageFilter;
+      $rootScope.settings.hideSourcesFilter = env.hideSourcesFilter;
+
+      // text displayed above the API list
+      $rootScope.settings.apiListHeaderText = env.apiListHeaderText;
+
   };
 
   // Initialize global settings

--- a/app/scripts/controllers/apis/list.js
+++ b/app/scripts/controllers/apis/list.js
@@ -10,7 +10,6 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
     /**
      * Public Variables
      */
-
     $scope.loading = 0; // Loading when > 0
     $scope.apis = [];
     $scope.filteredApis = [];
@@ -25,7 +24,14 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
         types: [],
         sources: []
     };
-    $scope.defaultProduct = false;
+    $scope.apiListHeaderText = $rootScope.settings.apiListHeaderText;
+    $scope.hideFilters = $rootScope.settings.hideFilters;
+    $scope.hideProductFilter = $rootScope.settings.hideProductFilter;
+    $scope.hideLanguageFilter = $rootScope.settings.hideLanguageFilter;
+    $scope.hideSourcesFilter = $rootScope.settings.hideSourcesFilter;
+
+    $scope.initDefaultFilters = false;
+
 
     /**
      * Private Variables
@@ -37,8 +43,47 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
      * Private Functions
      */
 
+    var setDefaultFilters = function() {
+        if ($scope.initDefaultFilters) {
+            // this is treated as a one shot
+            $scope.initDefaultFilters = false;
+            console.log("in setDefaultFilters")
+
+            if ($rootScope.settings.defaultFilters) {
+                console.log("setDefaultFilters actually setting initial filters")
+
+                if ($rootScope.settings.defaultFilters.sources) {
+                    angular.forEach($rootScope.settings.defaultFilters.sources, function (value, index) {
+                        $scope.filters.sources.push(value);
+                    });
+                }
+                if ($rootScope.settings.defaultFilters.products && $rootScope.settings.defaultFilters.products.length > 0) {
+                    angular.forEach($rootScope.settings.defaultFilters.products, function (value, index) {
+                        $scope.filters.products.push(value);
+                    });
+                }
+                if ($rootScope.settings.defaultFilters.languages) {
+                    angular.forEach($rootScope.settings.defaultFilters.languages, function (value, index) {
+                        $scope.filters.languages.push(value);
+                    });
+                }
+                if ($rootScope.settings.defaultFilters.types) {
+                    angular.forEach($rootScope.settings.defaultFilters.types, function (value, index) {
+                        $scope.filters.types.push(value);
+                    });
+                }
+                if ($rootScope.settings.defaultFilters.keywords) {
+                    $scope.filters.keywords = keywords;
+                }
+            }
+        }
+    }
     // Filters the available APIs according to selected "checkbox" filters
     var setFilteredApis = function(){
+
+        // check to see if we need to set default filters.  only done once.
+        setDefaultFilters();
+
         var apis = [];
 
         for (var x=0; x<$scope.apis.length; x++) {
@@ -147,7 +192,7 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
      * Public Functions
      */
 
-    var setDefaultFilters = false;
+
 
     // Load cached filters
     if (cache.get("filters")) {
@@ -155,8 +200,8 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
         setFilteredApis();
     } else {
         // there are no cached filters, so we need to set the default filter
-        // values after loading.
-        setDefaultFilters = true;
+        // values after we load for the first time.
+        $scope.initDefaultFilters = true;
     }
 
     $scope.loading += 1;
@@ -206,36 +251,4 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
         // Force filtering the APIs
         setFilteredApis();
     };
-
-    // check to see if there are default filter settings that we need to apply to the list
-    // of APIs now that we have them, only done first time the page loads.
-    if (setDefaultFilters && $rootScope.settings.defaultFilters) {
-        if ($rootScope.settings.defaultFilters.sources) {
-            angular.forEach($rootScope.settings.defaultFilters.sources, function (value, index) {
-                $scope.filters.sources.push(value);
-            });
-        }
-        if ($rootScope.settings.defaultFilters.products && $rootScope.settings.defaultFilters.products.length > 0) {
-            $scope.defaultProduct = true;
-            angular.forEach($rootScope.settings.defaultFilters.products, function (value, index) {
-                $scope.filters.products.push(value);
-            });
-        }
-        if ($rootScope.settings.defaultFilters.languages) {
-            angular.forEach($rootScope.settings.defaultFilters.languages, function (value, index) {
-                $scope.filters.languages.push(value);
-            });
-        }
-        if ($rootScope.settings.defaultFilters.types) {
-            angular.forEach($rootScope.settings.defaultFilters.types, function (value, index) {
-                $scope.filters.types.push(value);
-            });
-        }
-        if ($rootScope.settings.defaultFilters.keywords) {
-            $scope.filters.keywords = keywords;
-        }
-        // Force filtering the APIs
-        setFilteredApis();
-    }
-
 });

--- a/app/views/apis/detail.html
+++ b/app/views/apis/detail.html
@@ -213,7 +213,7 @@ table.prettytable {
         </div>
     </section>
 
-    <section ng-if="api.resources.docs" role="tabpanel" id="docs" ng-show="isTabActive(3)">
+    <section ng-if="api.resources.docs && (api.resources.docs.length > 0)" role="tabpanel" id="docs" ng-show="isTabActive(3)">
         <ul class="list-group list-group-flush">
             <li ng-repeat="doc in api.resources.docs" class="list-group-item">
                 <a href="{{::doc.downloadUrl}}" target="_blank">{{::doc.title}}</a>

--- a/app/views/apis/list.html
+++ b/app/views/apis/list.html
@@ -21,11 +21,11 @@
 
 <div class="row">
 
-    <div class="col-md-2 filters">
+    <div class="col-md-2 filters" ng-if="!hideFilters">
         <div class="card">
             <div class="card-header">Filters</div>
             <div class="card-block">
-                <div ng-if="defaultProduct == false &&  products.length && products.length > 1">
+                <div ng-if="(!hideProductFilter) &&  products.length && products.length > 1">
                     <h3 class="card-title">Products</h3>
                     <ul class="list-unstyled">
                         <li ng-repeat="product in products | orderBy:'toString()'">
@@ -38,7 +38,7 @@
                     <div class="card-divider"></div>
                 </div>
 
-                <div ng-if="languages.length && languages.length > 1">
+                <div ng-if="(!hideLanguageFilter) && languages.length && languages.length > 1">
                     <h3 class="card-title">Language Bindings</h3>
                     <ul class="list-unstyled">
                         <li ng-repeat="language in languages | orderBy:'toString()'">
@@ -65,7 +65,7 @@
                 </div>
                 -->
 
-                <div ng-if="sources.length && sources.length > 1">
+                <div ng-if="(!hideSourcesFilter) && sources.length && sources.length > 1">
                     <h3 class="card-title">Sources</h3>
                     <ul class="list-unstyled">
                         <li ng-repeat="source in sources | orderBy:'toString()'">
@@ -84,7 +84,7 @@
     <div class="col-md-9 apis">
 
         <div class="card">
-            <div class="card-header">Available APIs</div>
+            <div class="card-header">{{apiListHeaderText}}</div>
             <div class="card-block">
 
                 <div class="card-text">


### PR DESCRIPTION
Updated config.js with new hide* variables that control whether or not the entire
filter pane or particular sections (e.g products) are displayed for the user to
control them.  This is decoupled from the defaultFilters, so the net result is that
it is easily possible to configure the API Explorer such that you have an API explorer
scoped to a particular product with no possibility of changing it to see other products.
Also updated documentation accordingly.  Default behavior is unchanged.

Signed-off-by: Aaron Spear <aspear@vmware.com>