### PR TITLE
Added URI encoding of platform values 

### DIFF
--- a/app/scripts/services/api-explorer.js
+++ b/app/scripts/services/api-explorer.js
@@ -262,6 +262,7 @@
                     }
                     var url = $rootScope.settings.remoteSampleExchangeApiEndPoint + '/search/samples?';
                     angular.forEach(platform.split(","), function(value, index) {
+                        value = encodeURIComponent(value)
                     	if (index == 0) {
                     		url = url + 'platform=' + value;
                     	} else {
@@ -269,6 +270,8 @@
                     	}
 
                     });
+
+                    console.log("Trying to get samples " + url)
 
                     $http({
                         method : 'GET',
@@ -305,6 +308,7 @@
                         if (samples.length) {
                         	result = {data:{}};
                         	result.data = samples;
+                            console.log("got " + samples.length + " samples.")
                         }
                     },function(response) {
                     	var temp = response.data;


### PR DESCRIPTION
this way the search for samples in the case that the platform has a space in it will actually work correctly.  Tested with the staging server and it works.  It doesn't actually work with product yet because the search service on production is old and doesn't have the recently added support for being able to have an OR relationship between search queries.

Signed-off-by: Aaron Spear <aspear@vmware.com>