### PR TITLE
fixed issues with mutation of model resulting in bad page reloads

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -29,7 +29,8 @@ var app = angular.module('apiExplorerApp', [ 'ngAnimate', 'ngCookies', 'ngResour
               controller : 'ApisListCtrl'
           }).when('/apis/:id?', {
               templateUrl : 'views/apis/detail.html',
-              controller : 'ApisDetailCtrl'
+              controller : 'ApisDetailCtrl',
+              reloadOnSearch: false
           }).otherwise({
               redirectTo : '/apis'
           });

--- a/app/scripts/directives.js
+++ b/app/scripts/directives.js
@@ -73,7 +73,7 @@ app.directive('localIframe', ['$http', '$rootScope', '$window', function($http, 
                 //console.log("directive: $window.location.origin='" + $window.location.origin + "'");
                 //console.log("directive: $rootScope.settings.currentPath='" + $rootScope.settings.currentPath + "'");
                 //console.log("directive: attrs.localIframe='" + attrs.localIframe + "'");
-                //console.log("localIframe: url='" + url + "'");
+                console.log("localIframe: url='" + url + "'");
 
                 $http({
                     method : 'GET',

--- a/app/views/apis/detail.html
+++ b/app/views/apis/detail.html
@@ -154,10 +154,10 @@ table.prettytable {
             <a href="javascript:void(0);" ng-click="setActiveTab(2)" role="tab" aria-controls="apiReference" class="nav-link" ng-class="{active:isTabActive(2)}">API Reference</a>
         </li>
 
-        <li ng-if="api.resources.docs" role="presentation" class="nav-item">
+        <li ng-if="api.resources.docs && (api.resources.docs.length > 0)" role="presentation" class="nav-item">
             <a href="javascript:void(0);" ng-click="setActiveTab(3)" role="tab" aria-controls="docs" class="nav-link" ng-class="{active:isTabActive(3)}">Documentation</a>
         </li>
-        <li ng-if="api.resources.sdks" role="presentation" class="nav-item">
+        <li ng-if="api.resources.sdks && (api.resources.sdks.length > 0)" role="presentation" class="nav-item">
             <a href="javascript:void(0);" ng-click="setActiveTab(4)" role="tab" aria-controls="sdks" class="nav-link" ng-class="{active:isTabActive(4)}">Related SDKs</a>
         </li>
         <li ng-if="api.resources.samples" role="presentation" class="nav-item">
@@ -202,7 +202,7 @@ table.prettytable {
                 </div>
 
                 <iframe iframe-auto-size
-                    local-iframe="{{getTrustedUrl(settings.currentPath + 'swagger-console.html?url=' + api.url + '&host=' + api.swaggerPreferences.host + '&basePath=' + api.swaggerPreferences.basePath)}}">
+                        local-iframe="{{getTrustedUrl(settings.currentPath + 'swagger-console.html?url=' + api.url + '&host=' + api.swaggerPreferences.host + '&basePath=' + api.swaggerPreferences.basePath)}}">
                 </iframe>
 
                 <!--
@@ -227,7 +227,7 @@ table.prettytable {
         </ul>
     </section>
 
-    <section ng-if="api.resources.sdks" role="tabpanel" id="sdks" ng-show="isTabActive(4)">
+    <section ng-if="api.resources.sdks && (api.resources.sdks.length > 0)" role="tabpanel" id="sdks" ng-show="isTabActive(4)">
         <ul class="list-group list-group-flush">
             <li ng-repeat="sdk in api.resources.sdks | orderBy:'title'" class="list-group-item">
                 <div class="row">

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
-reverted change to remove usage of local-iframe for now
-reverted injection of usage of const instead of var on variables which apparently breaks karma tests
-used angular.copy to made a copy of the selected API since we change the API by loading remote resources.
 as a result there are no longer any ugly state loss issues when switching contexts.
-added option not to reload the page when searching in agulary controller setup

this is version 0.0.24

Signed-off-by: Aaron Spear <aspear@vmware.com>