### PR TITLE
made search case independent

### DIFF
--- a/app/scripts/controllers/apis/list.js
+++ b/app/scripts/controllers/apis/list.js
@@ -263,6 +263,23 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
 	}
 
     /**
+     * Method to check to see if a given method object matches the given keywords
+     * @param jsonObj
+     * @param keywords
+     * @returns {boolean}
+     */
+    $scope.methodMatchesKeywords = function(jsonObj, keywords) {
+	    // this should exit with false if the keywords is empty as well
+        if (!keywords || !jsonOb) {
+	        return false;
+        }
+        // the method has varying case for terms in it.  Here we make it lower case when doing
+        // the comparison so that it is case independent.  keywords is forced to be lower case
+        // already.
+        return angular.toJson(jsonObj, false).toLowerCase().indexOf(keywords) != -1;
+    }
+
+    /**
      * Public Functions
      */
 
@@ -309,6 +326,10 @@ angular.module('apiExplorerApp').controller('ApisListCtrl', function($rootScope,
 
     // When the "keywords" field has changed
     $scope.keywordsChanged = function(){
+
+        // force the keywords to lower case so that search is always case independent
+        $scope.filters.keywords = $scope.filters.keywords.toLowerCase();
+
         // Force filtering the APIs
         setFilteredApis();
     };


### PR DESCRIPTION
I changed the search routine so that it forcibly makes the keywords lowercase always (doesn't even let you type upper case, so that it implies that it is case independent).  Also changed the search so that when it is iterating all of the methods it makes them lower case.  It would be more efficient to make it all lower case when adding the methods, however this would mean it is all lower case in the method display which looks ugly.  So, this lower cases the method json when iterating.  It doesn't seem to be noticably slower.

This was requested by the AirWatch team.