### PR TITLE
Changed handling of query args in searching for samples

### DIFF
--- a/app/scripts/controllers/apis/detail.js
+++ b/app/scripts/controllers/apis/detail.js
@@ -106,7 +106,6 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
                     console.log("Removing API_OVERVIEW from resource list.");
                     overviewResource = resource;
                     docList.splice(i, 1);
-                    break;
                 }
             }
             if (docList.length == 0) {

--- a/app/scripts/services/api-explorer.js
+++ b/app/scripts/services/api-explorer.js
@@ -433,21 +433,16 @@
                     	return;
                     }
                     var url = $rootScope.settings.remoteSampleExchangeApiEndPoint + '/search/samples?';
-                    angular.forEach(platform.split(","), function(value, index) {
-                        value = encodeURIComponent(value)
-                    	if (index == 0) {
-                    		url = url + 'platform=' + value;
-                    	} else {
-                    		url = url + '&platform=' + value;
-                    	}
 
-                    });
+                    // aaron note: it seems that the apigw can only support the syntax of having a single instance of
+                    // a given query argument, so insteand of multiple platform values, pass all values comma separated.
+                    url = url + '&platform=' + encodeURIComponent(platform) + '&summary=true';
 
                     console.log("Trying to get samples " + url)
 
                     $http({
                         method : 'GET',
-                        url : url + '&summary=true'
+                        url : url
                     }).then(function(response) {
                     	var samples = [];
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
The VMware api gateway cannot handle multiple query args, so this changes the way that searches are done so that they are comma separated in a single value.  Also, changed the code that removes the API_OVERVIEW resource so that in the case of multiple values, one from the remote server and one local, they are both removed (happens for vRA)

Signed-off-by: Aaron Spear <aspear@vmware.com>