### PR TITLE
Added version info to the APIX build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,9 +12,10 @@ module.exports = function (grunt) {
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
 
-  grunt.loadNpmTasks( 'grunt-war' );
+  grunt.loadNpmTasks('grunt-war');
   grunt.loadNpmTasks('grunt-string-replace');
-
+  grunt.loadNpmTasks('grunt-gitinfo');
+  
   // Automatically load required Grunt tasks
   require('jit-grunt')(grunt, {
     useminPrepare: 'grunt-usemin',
@@ -27,7 +28,8 @@ module.exports = function (grunt) {
     app: require('./bower.json').appPath || 'app',
     version: require('./bower.json').version || '1.0.0',
     builddate: new Date(),
-    dist: 'dist'
+    dist: 'dist',
+    gitinfo: null
   };
 
   // Define the configuration for all the tasks
@@ -386,9 +388,17 @@ module.exports = function (grunt) {
         options: {
             replacements: [
                 {
+	                pattern: /APIX_GIT_SHA/g,
+	                replacement: '<%= gitinfo.local.branch.current.SHA %>'
+                },    
+                {
+	                pattern: /APIX_GIT_BRANCH/g,
+	                replacement: '<%= gitinfo.local.branch.current.name %>'
+                },    
+                {
 	                pattern: /APIX_VERSION/g,
 	                replacement: '<%= yeoman.version %>'
-                },
+                },                           
                 {
 	                pattern:  /APIX_BUILD_DATE/g,
 	                replacement: '<%= yeoman.builddate %>'
@@ -443,6 +453,9 @@ module.exports = function (grunt) {
         dest: '.tmp/styles/',
         src: '{,*/}*.css'
       }
+    },
+    gitinfo: {
+        options: {}
     },
 
     // Run some tasks in parallel to speed up the build process
@@ -520,6 +533,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('build', [
+    'gitinfo',
     'clean:dist',
     'wiredep',
     'useminPrepare',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
   require('time-grunt')(grunt);
 
   grunt.loadNpmTasks( 'grunt-war' );
+  grunt.loadNpmTasks('grunt-string-replace');
 
   // Automatically load required Grunt tasks
   require('jit-grunt')(grunt, {
@@ -25,6 +26,7 @@ module.exports = function (grunt) {
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
     version: require('./bower.json').version || '1.0.0',
+    builddate: new Date(),
     dist: 'dist'
   };
 
@@ -375,6 +377,27 @@ module.exports = function (grunt) {
       }
     },
 
+    // this code does a find/replace on the version.json file with APIX build info
+    'string-replace': {
+      dist: {
+        files: {
+          '<%= yeoman.dist %>/': '<%= yeoman.dist %>/version.json'
+        },
+        options: {
+            replacements: [
+                {
+	                pattern: /APIX_VERSION/g,
+	                replacement: '<%= yeoman.version %>'
+                },
+                {
+	                pattern:  /APIX_BUILD_DATE/g,
+	                replacement: '<%= yeoman.builddate %>'
+                }
+            ]
+        }
+      }
+    },
+
     // Copies remaining files to places other tasks can use
     copy: {
       dist: {
@@ -387,6 +410,8 @@ module.exports = function (grunt) {
             '*.{ico,png,txt}',
             '*.html',
             'local.json',
+            'version.json',
+            'local/{,*/}*.*',
             'config.js',
             'images/{,*/}*.{webp}',
             'styles/fonts/{,*/}*.*',
@@ -510,6 +535,7 @@ module.exports = function (grunt) {
     'filerev',
     'usemin',
     'htmlmin',
+    'string-replace',
     'war'
   ]);
 

--- a/app/version.json
+++ b/app/version.json
@@ -1,4 +1,6 @@
 {
+    "apix_git_branch" : "APIX_GIT_BRANCH",
+    "apix_git_sha"    : "APIX_GIT_SHA",
     "apix_version"    : "APIX_VERSION",
     "apix_build_date" : "APIX_BUILD_DATE",
     "package_version" : "PACKAGE_VERSION",

--- a/app/version.json
+++ b/app/version.json
@@ -1,0 +1,6 @@
+{
+    "apix_version"    : "APIX_VERSION",
+    "apix_build_date" : "APIX_BUILD_DATE",
+    "package_version" : "PACKAGE_VERSION",
+    "package_date"    : "PACKAGE_DATE"    
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^2.1.2",
+    "grunt-gitinfo": "^0.1.8",
     "grunt-google-cdn": "^0.4.3",
     "grunt-jscs": "^1.8.0",
     "grunt-karma": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-postcss": "^0.5.5",
+    "grunt-string-replace": "^1.3.1",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-war": "^0.5.1",


### PR DESCRIPTION
I realized as I was working on production ready version for vRA that we really should have some idea of what version of APIX is deployed on a given machine.  So, this change adds a new "version.json" file that contains a few fields that let you know info about the build.  I set the file up so that there are additionally fields that can simply be find/replaced by the packaging process as well, which means we have a way of also inserted build info of when APIX was packaged together with other content if someone cares about that.  The info looks like this in an APIX build:

{
    "apix_git_branch" : "added-version-to-build",
    "apix_git_sha"    : "ab31a5689ef9e5f5ca7e5e3944733ca9618de270",
    "apix_version"    : "0.0.31",
    "apix_build_date" : "Fri Aug 18 2017 16:33:49 GMT-0600 (MDT)",
    "package_version" : "PACKAGE_VERSION",
    "package_date"    : "PACKAGE_DATE"    
}

Yes, I did check what happens when you build in a working copy that is not a git clone, and the info is simply blank, but I thought it good to actually track that as well.