### PR TITLE
added working support for vRA SSO/token authorization

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -45,7 +45,17 @@
   window.config.remoteSampleExchangeApiEndPoint = "https://apigw.vmware.com/sampleExchange/v1";
   window.config.remoteApiEndPoint = "https://vdc-repo.vmware.com/apix";
 
-  // This is for vSphere SSO only.  To enable the SSO, set the ssoEnabled = true.
-  window.config.ssoEnabled = false;
-  window.config.authApiEndPoint = "https://10.154.10.43/rest/com/vmware/cis/session";
+  // By default SSO is disabled with a value of "none" for the ssoId. To enable it, 
+  // provide a supported string for the ssoId and a valid SSO endpoint host/path for
+  // window.config.authApiEndpoint
+  window.config.ssoId = "none";
+
+  // This is for vSphere SSO only.
+  //window.config.ssoId = "vsphere_sso";
+  //window.config.authApiEndPoint = "https://10.154.10.43/rest/com/vmware/cis/session";
+
+  //vRA SSO
+  //window.config.ssoId = "vra_sso";
+  //window.config.authApiEndPoint = "https://cava-p-14-062.eng.vmware.com/identity/api/tokens";
+  
 }(this));

--- a/app/index.html
+++ b/app/index.html
@@ -59,19 +59,39 @@
                 </a>
             </div>
 
-            <div class="settings" ng-if="settings.ssoEnabled">
+            <div class="settings" ng-if="settings.ssoId === 'vra_sso'">
 
-                <ul class="" ng-controller="UserSessionCtrl" >
+                <ul class="" ng-controller="VraUserSessionCtrl" >
 
                     <li class="dropdown" ng-if="loggedIn">
                         <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                             <span> Welcome {{username}} </span>
                             <span class="caret"></span>
                         </a>
-                        <a href="#" class="nav-link" ng-click="logout()">Log Out</a>
+                        <a href="#" class="nav-link" ng-click="vralogout()">Log Out</a>
                     </li>
                     <li ng-if="!loggedIn">
-                        <a href="javascript:void(0);" ng-click="login()">
+                        <a href="javascript:void(0);" ng-click="vralogin()">
+                            <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
+                            <span class="nav-link"> Log In </span>
+                        </a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="settings" ng-if="settings.ssoId === 'vsphere_sso'">
+
+                <ul class="" ng-controller="VsphereUserSessionCtrl" >
+
+                    <li class="dropdown" ng-if="loggedIn">
+                        <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <span> Welcome {{username}} </span>
+                            <span class="caret"></span>
+                        </a>
+                        <a href="#" class="nav-link" ng-click="vspherelogout()">Log Out</a>
+                    </li>
+                    <li ng-if="!loggedIn">
+                        <a href="javascript:void(0);" ng-click="vspherelogin()">
                             <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
                             <span class="nav-link"> Log In </span>
                         </a>
@@ -108,8 +128,10 @@
     <script src="bower_components/jquery-sieve/dist/jquery.sieve.js"></script>
     <script src="bower_components/jquery.throttle/src/jquery-throttle.js"></script>
     <script src="scripts/app.js"></script>
-    <script src="scripts/controllers/userSession.js"></script>
-    <script src="scripts/controllers/login.js"></script>
+    <script src="scripts/controllers/vraUserSession.js"></script>
+    <script src="scripts/controllers/vralogin.js"></script>
+    <script src="scripts/controllers/vsphereUserSession.js"></script>
+    <script src="scripts/controllers/vspherelogin.js"></script>
     <script src="scripts/directives.js"></script>
     <script src="scripts/services/api-explorer.js"></script>
     <script src="scripts/controllers/apis/list.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -84,7 +84,7 @@ app.run(function($rootScope, $window) {
       $rootScope.settings.apiListHeaderText = env.apiListHeaderText;
 
       // sso
-      $rootScope.settings.ssoEnabled = env.ssoEnabled;
+      $rootScope.settings.ssoId = env.ssoId;
       $rootScope.settings.authApiEndPoint = env.authApiEndPoint;
 
   };

--- a/app/scripts/controllers/apis/detail.js
+++ b/app/scripts/controllers/apis/detail.js
@@ -21,7 +21,7 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
 
     $scope.noOverviewMessage = "<i>No overview is available for this API.</i>";
 
-    $scope.sso = $rootScope.settings.ssoEnabled;
+    $scope.ssoId = $rootScope.settings.ssoId;
 
 
     /**

--- a/app/scripts/controllers/vraUserSession.js
+++ b/app/scripts/controllers/vraUserSession.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('apiExplorerApp').controller('UserSessionCtrl', function($rootScope, $scope, $window, $http, $cookies, ModalService, $sce, apis) {
+angular.module('apiExplorerApp').controller('VraUserSessionCtrl', function($rootScope, $scope, $window, $http, $cookies, ModalService, $sce, apis) {
 
     /**
      * Public Variables
@@ -19,11 +19,11 @@ angular.module('apiExplorerApp').controller('UserSessionCtrl', function($rootSco
      * Public Functions
      */
 
-    $scope.login = function() {
+    $scope.vralogin = function() {
 
         ModalService.showModal({
-            templateUrl : 'views/login.html',
-            controller : "LoginCtrl"
+            templateUrl : 'views/vralogin.html',
+            controller : "VraLoginCtrl"
         }).then(function(modal) {
             modal.element.modal();
             modal.close.then(function(result) {
@@ -43,7 +43,7 @@ angular.module('apiExplorerApp').controller('UserSessionCtrl', function($rootSco
 
     $scope.loading += 1;
 
-    $scope.logout = function() {
+    $scope.vralogout = function() {
         apis.logout(sessionStorage.getItem('vmware-api-session-id'), $sce.trustAsResourceUrl($rootScope.settings.authApiEndPoint)).then(function(response) {
 
         }).finally(function() {

--- a/app/scripts/controllers/vralogin.js
+++ b/app/scripts/controllers/vralogin.js
@@ -1,15 +1,15 @@
 'use strict';
 
-angular.module('apiExplorerApp').controller('LoginCtrl', function($rootScope, $scope, $http, $window, $timeout, $element, $sce, apis, close) {
+angular.module('apiExplorerApp').controller('VraLoginCtrl', function($rootScope, $scope, $http, $window, $timeout, $element, $sce, apis, close) {
 
     $scope.loggedInUser = null;
     $scope.user = {};
     $scope.errorMsg = null;
 
-    $scope.login = function() {
+    $scope.vralogin = function() {
         if ($scope.loginForm.$valid) {
 
-            apis.login($scope.user.name, $scope.user.password, $sce.trustAsResourceUrl($rootScope.settings.authApiEndPoint)).then(function(response) {
+            apis.vralogin($scope.user.name, $scope.user.password, $scope.user.tenant, $sce.trustAsUrl($rootScope.settings.authApiEndPoint)).then(function(response) {
                 if (response.value) {
                     console.log('have response, value=' + response.value);
                     $scope.loggedInUser = {
@@ -19,9 +19,9 @@ angular.module('apiExplorerApp').controller('LoginCtrl', function($rootScope, $s
 
                     $scope.close();
                 } else {
-                    $scope.errorMsg = "Login is failed.";
-                    $scope.statusMsg = "Login is failed.";
-                    console.log("bad");
+                    $scope.errorMsg = "Login failed.";
+                    $scope.statusMsg = "Login failed.";
+                    console.log("failed login response." + response);
                     $timeout(function() {
                         $scope.errorMsg = null;
                     }, 5000);

--- a/app/scripts/controllers/vsphereUserSession.js
+++ b/app/scripts/controllers/vsphereUserSession.js
@@ -1,0 +1,60 @@
+'use strict';
+
+angular.module('apiExplorerApp').controller('VsphereUserSessionCtrl', function($rootScope, $scope, $window, $http, $cookies, ModalService, $sce, apis) {
+
+    /**
+     * Public Variables
+     */
+    $scope.loading = 0; // Loading when > 0
+
+    /**
+     * Private Variables
+     */
+    var cookieNameUsername = "API-EXPLORER-USER";
+
+    $rootScope.loggedIn = (sessionStorage.getItem('vmware-api-session-id') || false);
+    $rootScope.username = ($cookies.get(cookieNameUsername) || null);
+
+    /**
+     * Public Functions
+     */
+
+    $scope.vspherelogin = function() {
+
+        ModalService.showModal({
+            templateUrl : 'views/vspherelogin.html',
+            controller : "VsphereLoginCtrl"
+        }).then(function(modal) {
+            modal.element.modal();
+            modal.close.then(function(result) {
+                if (result) {
+                    $rootScope.loggedIn = true;
+                    $rootScope.username = result.name;
+                    $cookies.put(cookieNameUsername, result.name);
+                    sessionStorage.setItem('vmware-api-session-id', result.sessionId );
+                }
+            });
+        }).catch(function(error) {
+
+            console.log(error);
+        });
+        //});
+    }
+
+    $scope.loading += 1;
+
+    $scope.vspherelogout = function() {
+        apis.logout(sessionStorage.getItem('vmware-api-session-id'), $sce.trustAsResourceUrl($rootScope.settings.authApiEndPoint)).then(function(response) {
+
+        }).finally(function() {
+            $rootScope.loggedIn = false;
+            $rootScope.username = null;
+
+            $cookies.remove(cookieNameUsername);
+            sessionStorage.removeItem('vmware-api-session-id');
+            $scope.loading -= 1;
+        });
+
+    }
+
+});

--- a/app/scripts/controllers/vspherelogin.js
+++ b/app/scripts/controllers/vspherelogin.js
@@ -1,0 +1,41 @@
+'use strict';
+
+angular.module('apiExplorerApp').controller('VsphereLoginCtrl', function($rootScope, $scope, $http, $window, $timeout, $element, $sce, apis, close) {
+
+    $scope.loggedInUser = null;
+    $scope.user = {};
+    $scope.errorMsg = null;
+
+    $scope.login = function() {
+        if ($scope.loginForm.$valid) {
+
+            apis.vspherelogin($scope.user.name, $scope.user.password, $sce.trustAsUrl($rootScope.settings.authApiEndPoint)).then(function(response) {
+                if (response.value) {
+                    console.log('have response, value=' + response.value);
+                    $scope.loggedInUser = {
+                        name: $scope.user.name,
+                        sessionId: response.value
+                    }
+
+                    $scope.close();
+                } else {
+                    $scope.errorMsg = "Login failed.";
+                    $scope.statusMsg = "Login failed.";
+                    console.log("failed login response." + response);
+                    $timeout(function() {
+                        $scope.errorMsg = null;
+                    }, 5000);
+                }
+            }).finally(function() {
+                console.log('In final');
+
+            });
+        }
+    }
+
+    // Close the dialog
+    $scope.close = function() {
+        $element.modal('hide');
+        close($scope.loggedInUser, 500);
+    };
+});

--- a/app/scripts/services/api-explorer.js
+++ b/app/scripts/services/api-explorer.js
@@ -172,7 +172,7 @@
 
         var definitions = {
                 // This is for vSphere only
-                login : function(username, password, authUrl) {
+                vspherelogin : function(username, password, authUrl) {
                     var deferred = $q.defer();
                     var result = angular.merge({}, emptyResult);
 
@@ -181,6 +181,7 @@
                         'Authorization': 'Basic ' + _authdata,
                         'vmware-use-header-authn' : 'apiexplorer'
                     };
+
                     $http({
                         method : 'POST',
                         url : authUrl,
@@ -193,8 +194,9 @@
 
                     return deferred.promise;
                 },
+
                 // This is for vSphere only
-                logout : function(sessionId, authUrl) {
+                vspherelogout : function(sessionId, authUrl) {
                     var deferred = $q.defer();
                     var result = angular.merge({}, emptyResult);
 
@@ -205,6 +207,77 @@
                     $http({
                         method : 'DELETE',
                         url : authUrl,
+                        headers: _headers
+                    }).then(function(response) {
+                        result = response.data;
+                        deferred.resolve(result);
+                    }).finally(function() {
+                        console.log('Failed to logout')
+                        deferred.resolve(result);
+                    });
+
+                    return deferred.promise;
+                },
+                // This is for vRA only
+                vralogin : function(username, password, tenant, authUrl) {
+                    var deferred = $q.defer();
+                    var result = angular.merge({}, emptyResult);
+
+                    //var _authdata = $base64.encode(username + ':' + password);
+                    //var _headers = {
+                    //    'Authorization': 'Basic ' + _authdata,
+                    //    'vmware-use-header-authn' : 'apiexplorer'
+                    //};
+                    // this is vRA SSO specific
+                    var _data = {
+                        "username" : username,
+                        "password" : password,
+                        "tenant"   : tenant
+                    };
+
+                    $http({
+                        method : 'POST',
+                        url : authUrl,
+                        data: _data
+                    }).then(function(response) {
+
+                        // return value looks like this:
+                        // {
+                        //    "expires": "2017-08-18T22:59:26.000Z",
+                        //    "id": "MTUwMzA2ODM2NjU2MDoxODA1OTY4OWEzODVjMTRiNjg0ZDp0ZW5hbnQ6dnNwaGVyZS5sb2NhbHVzZXJuYW1lOmFkbWluaXN0cmF0b3JAdnNwaGVyZS5sb2NhbGV4cGlyYXRpb246MTUwMzA5NzE2NjAwMDozMjQ0NzM3YTY5MzM5MmRmOGNmYmJlOTJhMjI0NTE1YjA2ZjM4ZTFmOWUyN2MxNjlkNDMwOGVlMjY5OGJiZTY2MDdkOTAwMjRjYjBjOWJmMWFkM2U5MjMyOWM1OGJlNGM4MmExYjMzNTc2N2M3YzMwYjU5ZWY4ZTdlNDFiMTg0ZA==",
+                        //    "tenant": "vsphere.local"
+                        //}
+
+                        result.value = response.data.id;
+                    }).finally(function() {
+                        deferred.resolve(result);
+                    });
+
+                    return deferred.promise;
+                },
+
+                // This is for vRA only
+                vralogout : function(sessionId, authUrl) {
+                    var deferred = $q.defer();
+                    var result = angular.merge({}, emptyResult);
+
+                    var _headers = {
+                        'Authorization': 'Token ' + sessionId,
+                    };
+
+                    var url = authUrl + "/" + sessionId;
+
+                    //var _authdata = $base64.encode(username + ':' + password);
+                    //var _headers = {
+                    //
+                    //    'vmware-use-header-authn' : 'apiexplorer'
+                    //};
+
+                     // https://{{va-fqdn}}/identity/api/tokens/{{token}}
+
+                    $http({
+                        method : 'DELETE',
+                        url : url,
                         headers: _headers
                     }).then(function(response) {
                         result = response.data;

--- a/app/swagger-console.html
+++ b/app/swagger-console.html
@@ -278,12 +278,16 @@
 			
                     window.swaggerUi.load();
 
-                    if (qs.sso) {
-                        //addApiKeyAuthorization();
-			var key = sessionStorage.getItem('vmware-api-session-id');
-			if (key && key.trim() != "") {
-			    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("vmware-api-session-id", key, "header");
-  		            window.swaggerUi.api.clientAuthorizations.add("vmware-api-session-id", apiKeyAuth);
+                    if (qs.ssoId) {
+                        var key = sessionStorage.getItem('vmware-api-session-id');
+                        if (key && key.trim() != "") {
+                            if (qs.ssoId == 'vra_sso') {
+                                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + key, "header");
+                                window.swaggerUi.api.clientAuthorizations.add("Authorization", apiKeyAuth);
+                            } else if (qs.ssoId == 'vsphere_sso') {
+                                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("vmware-api-session-id", key, "header");
+                                window.swaggerUi.api.clientAuthorizations.add("vmware-api-session-id", apiKeyAuth);
+                            }
                         }
                     }
 

--- a/app/views/apis/detail.html
+++ b/app/views/apis/detail.html
@@ -202,7 +202,7 @@ table.prettytable {
                 </div>
 
                 <iframe iframe-auto-size
-                    local-iframe="{{getTrustedUrl(settings.currentPath + 'swagger-console.html?url=' + api.url + '&host=' + api.swaggerPreferences.host + '&basePath=' + api.swaggerPreferences.basePath + '&sso=' + sso)}}">
+                    local-iframe="{{getTrustedUrl(settings.currentPath + 'swagger-console.html?url=' + api.url + '&host=' + api.swaggerPreferences.host + '&basePath=' + api.swaggerPreferences.basePath + '&sso=' + ssoId)}}">
                 </iframe>
 
                 <!--

--- a/app/views/vralogin.html
+++ b/app/views/vralogin.html
@@ -44,12 +44,13 @@
             </div>
             <div class="error">{{errorMsg}}</div>
             <div class="modal-body">
-
+                <span>vRealize Automation Login</span>
                 <form name="loginForm" class="form-signin" novalidate>
                     <input name="username" ng-model="user.name" type="text" class="form-control" placeholder="Username" required autofocus>
                     <input name="password" ng-model="user.password" type="password" class="form-control" placeholder="Password" required>
+                    <input name="tenant" ng-model="user.tenant" type="text" class="form-control" placeholder="Tenant" required>
 
-                    <button class="btn btn-lg btn-primary btn-block" type="submit" ng-disabled="loginForm.$invalid" ng-click="login()">Log in</button>
+                    <button class="btn btn-lg btn-primary btn-block" type="submit" ng-disabled="loginForm.$invalid" ng-click="vralogin()">Log in</button>
 
                 </form>
 

--- a/app/views/vspherelogin.html
+++ b/app/views/vspherelogin.html
@@ -1,0 +1,58 @@
+<div class="modal fade">
+
+<style>
+.modal-dialog.modal-lg {
+    width: 500px;
+}
+
+.form-signin .form-signin-heading, .form-signin .checkbox {
+    margin-bottom: 10px;
+}
+
+.form-signin .form-control {
+    position: relative;
+    height: auto;
+    padding: 10px;
+    font-size: 16px;
+}
+
+.form-signin .form-control:focus {
+    z-index: 2;
+}
+
+.form-signin input[type="password"] {
+    margin-bottom: 10px;
+    margin-top: 10px;
+    width: 100%;
+}
+
+.form-signin input[type="text"] {
+    margin-bottom: 10px;
+    margin-top: 10px;
+    width: 100%;
+}
+.error {
+    color: red;
+}
+</style>
+
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" ng-click="close()" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Log In</h4>
+            </div>
+            <div class="error">{{errorMsg}}</div>
+            <div class="modal-body">
+                <form name="loginForm" class="form-signin" novalidate>
+                    <input name="username" ng-model="user.name" type="text" class="form-control" placeholder="Username" required autofocus>
+                    <input name="password" ng-model="user.password" type="password" class="form-control" placeholder="Password" required>
+
+                    <button class="btn btn-lg btn-primary btn-block" type="submit" ng-disabled="loginForm.$invalid" ng-click="login()">Log in</button>
+
+                </form>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
Right now this was done by simply cloning the previously hard coded vsphere support and
renaming it.  Now, but the vsphere and vra SSO implementations exist in the code, named
appropriately, and you can select which one you want by specifying a new ssoId string
value in the config.js file.

I don't actually think this is the ideal implementation by any means, but it seemed
like the most simple path to be able to enable vRA SSO and vSphere SSO to live together
 in the same code base short term.  I think a better implementation would allow
individual APIs to specify the ssoId that they want to use and then the particular
SSO that appears when you hit the log in button would depend on which API you were using.
It should be possible for them to be used simultaneously, which would also require using
 of a different cookie for each one.

Signed-off-by: Aaron Spear <aspear@vmware.com>