### PR TITLE
Added version info to version.json in build

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -13,7 +13,8 @@
                 "apix-components",
                 "local.json",
                 "local",
-                "examples"
+                "examples",
+                "version.json"
             ],
             "index": "index.html",
             "main": "main.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "start": "ng serve",
     "test": "echo success",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "build": "ng build --prod",
+    "postbuild": "bash set-version.sh"
   },
   "private": true,
   "dependencies": {

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is a post build step that fixes up the information in the ./dist/version.json
+# to reflect the variables of this particular build
+
+BRANCH_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+VERSION_FILE=${BRANCH_DIR}/dist/version.json
+
+NOW=`date +%FT%T%Z`
+APIX_VERSION=`grep \"version\" ./package.json | sed 's/[\",]//g' | sed 's/[ \t]*version:[ \t]*//g'`
+: "${BRANCH_NAME:=`git rev-parse --abbrev-ref HEAD`}"
+: "${CHANGE_NUMBER:=`git rev-parse HEAD`}"
+: "${BUILD_NUMBER:=0}"
+
+#echo "BUILD_NUMBER=${BUILD_NUMBER}"
+#echo "BRANCH_NAME=${BRANCH_NAME}"
+#echo "CHANGE_NUMBER=${CHANGE_NUMBER}"
+#echo "APIX_VERSION=${APIX_VERSION}"
+#echo "NOW=${NOW}"
+
+if [ -f ${VERSION_FILE} ]; then
+    sed -i "s/APIX_GIT_SHA/${CHANGE_NUMBER}/g" ${VERSION_FILE}
+    sed -i "s/APIX_GIT_BRANCH/${BRANCH_NAME}/g" ${VERSION_FILE}
+    sed -i "s/APIX_VERSION/${APIX_VERSION}/g" ${VERSION_FILE}
+    sed -i "s/APIX_BUILD_DATE/${NOW} build:${BUILD_NUMBER}/g" ${VERSION_FILE}
+    sed -i "s/APIX_BUILD_NUMBER/${BUILD_NUMBER}/g" ${VERSION_FILE}
+else
+    echo "version file '${VERSION_FILE}' does not exist."
+    exit 1
+fi


### PR DESCRIPTION
added new shell script that can be called to set the version.json info
post build, also added npm postbuild task that calls it.  it is NOT wired
up to the ng build right now however as I could not figure that out.

Signed-off-by: Aaron Spear <aspear@vmware.com>