### PR TITLE
Support for new APIX services with explicit API version 

### DIFF
--- a/app/scripts/controllers/apis/detail.js
+++ b/app/scripts/controllers/apis/detail.js
@@ -233,6 +233,7 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
             if (!$scope.api || ($scope.api && $scope.api.id !== selectedApi.id)) {
                 // because we mutate the api with removing resources and merging remote resources into it possibly,
                 // we make a copy here.
+		console.log(selectedApi) //FIXME
                 $scope.api = angular.copy(selectedApi);
 
                 if ( true ) { //! $scope.api.isLoaded
@@ -246,8 +247,11 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
                         loadResourcesForRemoteApi($scope.api.id);
                     } else if ($scope.api.url && $scope.api.source == 'local') {
                         if ($scope.api.api_uid) {
-                            console.log("fetching remote resources for local api_uid=" + $scope.api.api_uid);
-                            apis.getLatestRemoteApiIdForApiUid($scope.api.api_uid).then(function (response) {
+                            console.log("fetching remote resources for local api_uid=" + $scope.api.api_uid + " version=" + $scope.api.version);
+
+                            console.log( $scope.api )
+
+                            apis.getLatestRemoteApiIdForApiUid($scope.api.api_uid, $scope.api.version).then(function (response) {
                                 // response.data should have the id.  Might be null
                                 loadResourcesForRemoteApi(response.data);
                             }).finally(function () {
@@ -257,7 +261,6 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
                             console.log("No api_uid. synchronizing local resources.");
                             loadResourcesForRemoteApi(null);
                         }
-
                     }
 
                     if ($scope.api.type === "swagger") {

--- a/app/scripts/services/api-explorer.js
+++ b/app/scripts/services/api-explorer.js
@@ -563,13 +563,22 @@
                 * versions from the web service and returns the id of the latest one in the result.data.
                 * @return a promise for an object with data = id of the API
                 */
-                getLatestRemoteApiIdForApiUid : function(api_uid) {
+                getLatestRemoteApiIdForApiUid : function(api_uid, api_version) {
                     var deferred = $q.defer();
                     var result = {data:null};
 
+                    var endpointUrl=null;
+                    if (api_version) {
+                        endpointUrl = $rootScope.settings.remoteApisEndpoint + '/apis/uids/' + api_uid + "/versions/" + api_version
+                    } else {
+                        // legacy no version case
+                        endpointUrl = $rootScope.settings.remoteApisEndpoint + '/apis/uids/' + api_uid
+                    }
+
+                    console.log("getting APIs using " + endpointUrl)
                     $http({
                         method : 'GET',
-                        url : $rootScope.settings.remoteApisEndpoint + '/apis/uids/' + api_uid
+                        url : endpointUrl
                     }).then(function(response) {
 
                         //console.log("got response " + response)
@@ -581,7 +590,7 @@
                             angular.forEach(response.data, function(value, index) {
                                 console.log("api_uid=" + api_uid + " id=" + value.id + " version=" + value.version);
                             });
-                            // get the last one
+                            // get the first one
                             result.data = response.data[response.data.length-1].id;
 
                         } else {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
This patch enables calling updated VMware APIX services that support an explicit version of an API.  Previously the code simply looked up the latest one, which can result in getting new documents for an old version which is bad form.