### PR TITLE
version 1.1.2 fix for issues with FireFox and javascript:void(0)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -71,7 +71,7 @@
                         <a href="#" class="nav-link" ng-click="vralogout()">Log Out</a>
                     </li>
                     <li ng-if="!loggedIn">
-                        <a href="javascript:void(0);" ng-click="vralogin()">
+                        <a href="#" ng-click="vralogin()">
                             <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
                             <span class="nav-link"> Log In </span>
                         </a>
@@ -88,7 +88,7 @@
                         <a href="#" class="nav-link" ng-click="vspherelogout()">Log Out</a>
                     </li>
                     <li ng-if="!loggedIn">
-                        <a href="javascript:void(0);" ng-click="vspherelogin()">
+                        <a href="#" ng-click="vspherelogin()">
                             <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
                             <span class="nav-link"> Log In </span>
                         </a>
@@ -105,7 +105,7 @@
                         <a href="#" class="nav-link" ng-click="basiclogout()">Log Out</a>
                     </li>
                     <li ng-if="!loggedIn">
-                        <a href="javascript:void(0);" ng-click="basiclogin()">
+                        <a href="#" ng-click="basiclogin()">
                             <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span>
                             <span class="nav-link"> Log In </span>
                         </a>

--- a/app/views/apis/detail.html
+++ b/app/views/apis/detail.html
@@ -167,21 +167,21 @@ table.prettytable {
     <ul ng-if="api.resources && (api.overviewHtml || api.resources.docs || api.resources.samples || api.resources.sdks)" id="tabs" class="nav" role="tablist">
 
         <li ng-show="api.overviewHtml" role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(1)" role="tab" aria-controls="overview" class="nav-link" ng-class="{active:isTabActive(1)}">Overview</a>
+            <a href="#" ng-click="setActiveTab(1)" role="tab" aria-controls="overview" class="nav-link" ng-class="{active:isTabActive(1)}">Overview</a>
         </li>
 
         <li role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(2)" role="tab" aria-controls="apiReference" class="nav-link" ng-class="{active:isTabActive(2)}">API Reference</a>
+            <a href="#" ng-click="setActiveTab(2)" role="tab" aria-controls="apiReference" class="nav-link" ng-class="{active:isTabActive(2)}">API Reference</a>
         </li>
 
         <li ng-if="api.resources.docs && (api.resources.docs.length > 0)" role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(3)" role="tab" aria-controls="docs" class="nav-link" ng-class="{active:isTabActive(3)}">Documentation</a>
+            <a href="#" ng-click="setActiveTab(3)" role="tab" aria-controls="docs" class="nav-link" ng-class="{active:isTabActive(3)}">Documentation</a>
         </li>
         <li ng-if="api.resources.sdks && (api.resources.sdks.length > 0)" role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(4)" role="tab" aria-controls="sdks" class="nav-link" ng-class="{active:isTabActive(4)}">Related SDKs</a>
+            <a href="#" ng-click="setActiveTab(4)" role="tab" aria-controls="sdks" class="nav-link" ng-class="{active:isTabActive(4)}">Related SDKs</a>
         </li>
         <li ng-if="api.resources.samples" role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(5)" role="tab" aria-controls="samples" class="nav-link" ng-class="{active:isTabActive(5)}">Related Code Samples</a>
+            <a href="#" ng-click="setActiveTab(5)" role="tab" aria-controls="samples" class="nav-link" ng-class="{active:isTabActive(5)}">Related Code Samples</a>
         </li>
 
     </ul>

--- a/app/views/apis/list.html
+++ b/app/views/apis/list.html
@@ -178,10 +178,10 @@ i {
     <ul ng-if="overviewHtml" id="tabs" class="nav" role="tablist">
 
         <li ng-show="overviewHtml" role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(1)" role="tab" aria-controls="overview" class="nav-link" ng-class="{active:isTabActive(1)}">Overview</a>
+            <a href="#" ng-click="setActiveTab(1)" role="tab" aria-controls="overview" class="nav-link" ng-class="{active:isTabActive(1)}">Overview</a>
         </li>
         <li role="presentation" class="nav-item">
-            <a href="javascript:void(0);" ng-click="setActiveTab(2)" role="tab" aria-controls="apis" class="nav-link" ng-class="{active:isTabActive(2)}">Apis</a>
+            <a href="#" ng-click="setActiveTab(2)" role="tab" aria-controls="apis" class="nav-link" ng-class="{active:isTabActive(2)}">Apis</a>
         </li>
     </ul>
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
apparently a new version of firefox marks this as being unsafe by default.  The fix is to change it to simply be # instead.

Signed-off-by: Aaron Spear <aspear@vmware.com>