### PR TITLE
version 1.1.14: security patch for vulnerability with swagger_console

### DIFF
--- a/app/scripts/controllers/apis/detail.js
+++ b/app/scripts/controllers/apis/detail.js
@@ -269,20 +269,6 @@ angular.module('apiExplorerApp').controller('ApisDetailCtrl', function($rootScop
                         if ($scope.api.url) {
 
                             var apiUrl = $scope.api.url;
-                            // if (ABSOLUTE_URL_RE.test($scope.api.url)) {
-                            //     apiUrl = $scope.api.url;
-                            // } else {
-                            //     if ($scope.api.url.startsWith("/")) {
-                            //         if ($rootScope.settings.currentPath.endsWith('/')) {
-                            //             // remove redundant slash
-                            //             apiUrl = $rootScope.settings.currentPath + $scope.api.url.substring(1);
-                            //         } else {
-                            //             apiUrl = $rootScope.settings.currentPath + $scope.api.url;
-                            //         }
-                            //     } else {
-                            //         apiUrl = $rootScope.settings.currentPath + $scope.api.url;
-                            //     }
-                            // }
 
                             if ($scope.showSwaggerPreferences) {
                                 $scope.loading += 1;

--- a/app/swagger-console.html
+++ b/app/swagger-console.html
@@ -227,17 +227,14 @@
 
             if (qs.url) {
                 var url = qs.url
-                // if (!url.startsWith('http')) {
-                //     var fullurl = window.location.protocol + "//" + window.location.hostname + (window.location.port ? (":" + window.location.port) : "")
-                //     if (url.startsWith("/")) {
-                //         url = fullurl + url;
-                //     } else {
-                //         url = fullurl + "/" + url;
-                //     }
-                // }
-                // console.log("converted url='" + qs.url + "' to '" + url + "'")
 
-                //$.getJSON(url, function(json) {
+                // validate that we were passed a relative URL and exit with an error message if it is not.
+                var ABSOLUTE_URL_RE = new RegExp('^(?:[a-z]+:)?//', 'i');
+                if (ABSOLUTE_URL_RE.test(url)) {
+                    $("#swagger-ui-container").empty().append("<p>Oops!  Request failed! The API documentation at " +  qs.url + " is an absolute URL.  Only relative URLs are supported.</p>");
+                    return;
+                }
+
                 getSwaggerJson(url, function(json) {
 
                     // Override "host"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "api-explorer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "dependencies": {
     "jquery": "2.x",
     "jquery.throttle": "^1.0.0",


### PR DESCRIPTION
Now only relative URLs allowed in this version.
This also includes some cleanup of dead code with no functional change.

Signed-off-by: Aaron Spear <aspear@vmware.com>