### PR TITLE
URL Encode querystring written to page

### DIFF
--- a/app/swagger-console.html
+++ b/app/swagger-console.html
@@ -231,7 +231,7 @@
                 // validate that we were passed a relative URL and exit with an error message if it is not.
                 var ABSOLUTE_URL_RE = new RegExp('^(?:[a-z]+:)?//', 'i');
                 if (ABSOLUTE_URL_RE.test(url)) {
-                    $("#swagger-ui-container").empty().append("<p>Oops!  Request failed! The API documentation at " +  qs.url + " is an absolute URL.  Only relative URLs are supported.</p>");
+                    $("#swagger-ui-container").empty().append("<p>Oops!  Request failed! The API documentation at " +  encodeURI(qs.url) + " is an absolute URL.  Only relative URLs are supported.</p>");
                     return;
                 }
 
@@ -342,7 +342,7 @@
                     }
 
                 }).fail(function(event, textStatus, error) {
-                    $("#swagger-ui-container").empty().append("<p>Oops!  Request failed! The API documentation at " +  qs.url + " gives error: " + error + "</p>");
+                    $("#swagger-ui-container").empty().append("<p>Oops!  Request failed! The API documentation at " +  encodeURI(qs.url) + " gives error: " + error + "</p>");
                 })
 
             }


### PR DESCRIPTION
URL encode the query string that is appened to the page
on swagger-console load failure. This is to prevent an
attacker from forming a malicious link that looks
legitimate but really contains a harmful payload.